### PR TITLE
bring back api validation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
         args: -p bugs -p unused --timeout=3m
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/klauspost/connect-compress v1.0.0
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/zap v1.24.0
+	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb
 	google.golang.org/protobuf v1.28.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,8 @@ golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4
 golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb h1:PaBZQdo+iSDyHT053FjUCgZQ/9uqVwPOcl7KSWhKn6w=
+golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,6 @@ github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYr
 github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
-github.com/bufbuild/connect-go v1.5.0 h1:IfbgbzzaaZvF+OM3SfxO2EjtvNJarNAz2DIRuuNjAgc=
-github.com/bufbuild/connect-go v1.5.0/go.mod h1:9iNvh/NOsfhNBUH5CtvXeVUskQO1xsrEviH7ZArwZ3I=
 github.com/bufbuild/connect-go v1.5.1 h1:ORhrSiu63hWxtuMmC/V1mKySSRhEySsW5RkHJcyJXBk=
 github.com/bufbuild/connect-go v1.5.1/go.mod h1:9iNvh/NOsfhNBUH5CtvXeVUskQO1xsrEviH7ZArwZ3I=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -110,8 +108,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
-golang.org/x/crypto v0.5.0 h1:U/0M97KRkSFvyD/3FSmdP5W5swImpNgle/EHFhOsQPE=
-golang.org/x/crypto v0.5.0/go.mod h1:NK/OQwhpMQP3MwtdjgLlYHnH9ebylxKWv3e0fK+mkQU=
 golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -129,7 +125,7 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
-golang.org/x/net v0.5.0 h1:GyT4nK/YDHSqa1c4753ouYCDajOYKTja9Xb/OHtgvSw=
+golang.org/x/net v0.6.0 h1:L4ZwwTvKW9gr0ZMS1yrHD9GZhIuVjOBBnaKH+SPQK0Q=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -145,7 +141,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
+golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
@@ -154,7 +150,7 @@ golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
-golang.org/x/text v0.6.0 h1:3XmdazWV+ubf7QgHSTWeykHOci5oeekaGJBLkrkaw4k=
+golang.org/x/text v0.7.0 h1:4BRB4x83lYWy72KwLD/qYDuTu7q9PjSagHvijDw7cLo=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
@@ -169,8 +165,6 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20230127162408-596548ed4efa h1:GZXdWYIKckxQE2EcLHLvF+KLF+bIwoxGdMUxTZizueg=
-google.golang.org/genproto v0.0.0-20230127162408-596548ed4efa/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/genproto v0.0.0-20230209215440-0dfe4f8abfcc h1:ijGwO+0vL2hJt5gaygqP2j6PfflOBrRot0IczKbmtio=
 google.golang.org/genproto v0.0.0-20230209215440-0dfe4f8abfcc/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/go/tests/api_scopes_test.go
+++ b/go/tests/api_scopes_test.go
@@ -87,7 +87,7 @@ func getProtos(root string) ([]string, error) {
 		}
 	)
 
-	files, err := walk("../../proto")
+	files, err := walk(root)
 	if err != nil {
 		return nil, err
 	}
@@ -133,6 +133,25 @@ func Test_APIScopes(t *testing.T) {
 								t.Errorf("api service method: %q can not have %s and %s (%s) at the same time. only one scope is allowed.", methodName, methodScope, name, s)
 							}
 							methodScope = fmt.Sprintf("%s (%s)", name, s)
+						}
+
+						if name == "project scope" && len(s) > 0 {
+							projectFound := false
+							projectRequest := ""
+							for _, mt := range fd.GetMessageType() {
+								if *mt.Name != method.GetInputType() {
+									continue
+								}
+								for _, field := range mt.Field {
+									if *field.Name == "project" {
+										projectFound = true
+									}
+								}
+								projectRequest = *mt.Name
+							}
+							if !projectFound {
+								t.Errorf("api service method: %q has project scope but request payload %q does not have a project field", methodName, projectRequest)
+							}
 						}
 					}
 

--- a/go/tests/api_scopes_test.go
+++ b/go/tests/api_scopes_test.go
@@ -1,44 +1,163 @@
 package apitests
 
-// import (
-// 	"fmt"
-// 	"testing"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
 
-// 	"github.com/metal-stack-cloud/api/go/permissions"
-// 	"github.com/stretchr/testify/require"
-// )
+	"github.com/jhump/protoreflect/desc/protoparse"
+	v1 "github.com/metal-stack-cloud/api/go/api/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
 
-// func Test_APIScopes(t *testing.T) {
+type (
+	tenant     struct{}
+	project    struct{}
+	admin      struct{}
+	visibility struct{}
+)
 
-// 	servicePermissions, err := permissions.Get()
-// 	require.NoError(t, err)
-// 	for _, method := range servicePermissions.Methods {
-// 		var (
-// 			scopes = map[string][]string{
-// 				"tenant scope":     tenant{}.Get(method.Options),
-// 				"project scope":    project{}.Get(method.Options),
-// 				"admin scope":      admin{}.Get(method.Options),
-// 				"visibility scope": visibility{}.Get(method.Options),
-// 			}
-// 			allScopeNames = func() (names []string) {
-// 				for name := range scopes {
-// 					names = append(names, name)
-// 				}
-// 				return
-// 			}()
-// 		)
-// 		for name, s := range scopes {
-// 			if len(s) > 0 {
-// 				if methodScope != "" {
-// 					t.Errorf("api service method: %q can not have %s and %s (%s) at the same time. only one scope is allowed.", methodName, methodScope, name, s)
-// 				}
-// 				methodScope = fmt.Sprintf("%s (%s)", name, s)
-// 			}
-// 		}
+func (tenant) Get(methodOpts []*descriptorpb.UninterpretedOption) (scopes []string) {
+	for _, methodOpt := range methodOpts {
+		for _, namePart := range methodOpt.Name {
+			if !*namePart.IsExtension {
+				continue
+			}
+			switch *methodOpt.IdentifierValue {
+			case v1.TenantRole_TENANT_ROLE_OWNER.String():
+				scopes = append(scopes, *methodOpt.IdentifierValue)
+			case v1.TenantRole_TENANT_ROLE_EDITOR.String():
+				scopes = append(scopes, *methodOpt.IdentifierValue)
+			case v1.TenantRole_TENANT_ROLE_VIEWER.String():
+				scopes = append(scopes, *methodOpt.IdentifierValue)
+			}
+		}
+	}
+	return
+}
 
-// 		if methodScope == "" {
-// 			t.Errorf("api service method: %q has no scope defined. one scope needs to be defined though. use one of the following scopes: %s", methodName, allScopeNames)
-// 		}
-// 	}
+func (project) Get(methodOpts []*descriptorpb.UninterpretedOption) (scopes []string) {
+	for _, methodOpt := range methodOpts {
+		for _, namePart := range methodOpt.Name {
+			if !*namePart.IsExtension {
+				continue
+			}
+			switch *methodOpt.IdentifierValue {
+			case v1.ProjectRole_PROJECT_ROLE_OWNER.String():
+				scopes = append(scopes, *methodOpt.IdentifierValue)
+			case v1.ProjectRole_PROJECT_ROLE_EDITOR.String():
+				scopes = append(scopes, *methodOpt.IdentifierValue)
+			case v1.ProjectRole_PROJECT_ROLE_VIEWER.String():
+				scopes = append(scopes, *methodOpt.IdentifierValue)
+			}
+		}
+	}
+	return
+}
 
-// }
+func (admin) Get(methodOpts []*descriptorpb.UninterpretedOption) (scopes []string) {
+	for _, methodOpt := range methodOpts {
+		for _, namePart := range methodOpt.Name {
+			if !*namePart.IsExtension {
+				continue
+			}
+			switch *methodOpt.IdentifierValue {
+			case v1.AdminRole_ADMIN_ROLE_EDITOR.String():
+				scopes = append(scopes, *methodOpt.IdentifierValue)
+			case v1.AdminRole_ADMIN_ROLE_VIEWER.String():
+				scopes = append(scopes, *methodOpt.IdentifierValue)
+			}
+		}
+	}
+	return
+}
+
+func (visibility) Get(methodOpts []*descriptorpb.UninterpretedOption) (scopes []string) {
+	for _, methodOpt := range methodOpts {
+		for _, namePart := range methodOpt.Name {
+			if !*namePart.IsExtension {
+				continue
+			}
+			switch *methodOpt.IdentifierValue {
+			case v1.Visibility_VISIBILITY_PUBLIC.String():
+				scopes = append(scopes, *methodOpt.IdentifierValue)
+			case v1.Visibility_VISIBILITY_PRIVATE.String():
+				scopes = append(scopes, *methodOpt.IdentifierValue)
+			}
+		}
+	}
+	return
+}
+
+func Test_APIScopes(t *testing.T) {
+
+	var (
+		walk = func(root string) ([]string, error) {
+			var files []string
+			err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+				if info.IsDir() {
+					return nil
+				}
+				if strings.HasSuffix(info.Name(), ".proto") {
+					files = append(files, path)
+				}
+				return nil
+			})
+			return files, err
+		}
+	)
+
+	files, err := walk("../../proto")
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	for _, f := range files {
+		p := protoparse.Parser{}
+		fds, err := p.ParseFilesButDoNotLink(f)
+		if err != nil {
+			require.NoError(t, err)
+		}
+		for _, fd := range fds {
+			for _, serviceDesc := range fd.GetService() {
+				for _, method := range serviceDesc.GetMethod() {
+					var (
+						methodName  = fmt.Sprintf("/%s.%s/%s", *fd.Package, *serviceDesc.Name, *method.Name)
+						methodOpts  = method.Options.GetUninterpretedOption()
+						methodScope = ""
+						scopes      = map[string][]string{
+							"tenant scope":     tenant{}.Get(methodOpts),
+							"project scope":    project{}.Get(methodOpts),
+							"admin scope":      admin{}.Get(methodOpts),
+							"visibility scope": visibility{}.Get(methodOpts),
+						}
+						allScopeNames = func() (names []string) {
+							for name := range scopes {
+								names = append(names, name)
+							}
+							return
+						}()
+					)
+					// fmt.Printf("method:%s opts:%#v\n", methodName, method.Options)
+
+					for name, s := range scopes {
+						if len(s) > 0 {
+							if methodScope != "" {
+								t.Errorf("api service method: %q can not have %s and %s (%s) at the same time. only one scope is allowed.", methodName, methodScope, name, s)
+							}
+							methodScope = fmt.Sprintf("%s (%s)", name, s)
+						}
+					}
+
+					if methodScope == "" {
+						t.Errorf("api service method: %q has no scope defined. one scope needs to be defined though. use one of the following scopes: %s", methodName, allScopeNames)
+					}
+				}
+			}
+		}
+	}
+
+}

--- a/go/tests/api_scopes_test.go
+++ b/go/tests/api_scopes_test.go
@@ -70,8 +70,7 @@ func getScopes(methodOpts []*descriptorpb.UninterpretedOption, identifiers []str
 	return
 }
 
-func Test_APIScopes(t *testing.T) {
-
+func getProtos(root string) ([]string, error) {
 	var (
 		walk = func(root string) ([]string, error) {
 			var files []string
@@ -89,6 +88,14 @@ func Test_APIScopes(t *testing.T) {
 	)
 
 	files, err := walk("../../proto")
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}
+
+func Test_APIScopes(t *testing.T) {
+	files, err := getProtos("../../proto")
 	if err != nil {
 		require.NoError(t, err)
 	}

--- a/go/tests/testproto/wrongproject.proto
+++ b/go/tests/testproto/wrongproject.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package api.v1;
+
+import "api/v1/common.proto";
+
+service WrongProjectService {
+  rpc Get(WrongProjectServiceGetRequest) returns (WrongProjectServiceGetResponse) {
+    option (project_roles) = PROJECT_ROLE_OWNER;
+  }
+  rpc List(WrongProjectServiceGetRequest) returns (WrongProjectServiceGetResponse) {
+  }
+  rpc Update(WrongProjectServiceUpdateRequest) returns (WrongProjectServiceUpdateResponse) {
+    option (admin_roles) = ADMIN_ROLE_VIEWER;
+    option (project_roles) = PROJECT_ROLE_OWNER;
+  }
+  rpc Delete(WrongProjectServiceUpdateRequest) returns (WrongProjectServiceUpdateResponse) {
+    option (admin_roles) = ADMIN_ROLE_VIEWER;
+    option (api.v1.visibility) = VISIBILITY_PUBLIC;
+  }
+}
+
+message WrongProjectServiceGetRequest {
+    string uuid = 1;
+}
+
+message WrongProjectServiceGetResponse {
+    string uuid = 1;
+}
+message WrongProjectServiceUpdateRequest {
+    string uuid = 1;
+    string project = 2;
+}
+
+message WrongProjectServiceUpdateResponse {
+    string uuid = 1;
+}

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -1,5 +1,5 @@
 MAKEFLAGS += --no-print-directory
-BUF_VERSION := 1.13.1
+BUF_VERSION := 1.14.0
 
 _buf:
 	docker run --rm \

--- a/proto/buf.gen.yaml
+++ b/proto/buf.gen.yaml
@@ -30,3 +30,8 @@ plugins:
   - plugin: buf.build/community/pseudomuto-doc:v1.5.1
     out: ../docs
     opt: json,docs.json
+  # Create python client
+  # - plugin: buf.build/protocolbuffers/python:v21.12
+  #   out: ../python
+  # - plugin: buf.build/grpc/python:v1.52.0
+  #   out: ../python


### PR DESCRIPTION
Once we missed a api contract validation, prevent that.

Also added a invalid `proto` file to test the test validity.

go-1.20 multiple errors feature used !