### PR TITLE
explicitly make the api js to a module

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -9,6 +9,7 @@
   },
   "author": "",
   "license": "MIT",
+  "type": "module",
   "dependencies": {
     "@bufbuild/connect-web": "^0.13.0",
     "@bufbuild/protobuf": "^1.6.0"


### PR DESCRIPTION
So the website can import it correctly again. 